### PR TITLE
chore: add AsyncAPI v2.5.0 schema to the `all.schema-store.json` doc.

### DIFF
--- a/schemas/all.schema-store.json
+++ b/schemas/all.schema-store.json
@@ -144,6 +144,20 @@
           "$ref": "http://asyncapi.com/schema-store/2.4.0.json"
         }
       ]
+    },
+    {
+      "allOf": [
+        {
+          "properties": {
+            "asyncapi": {
+              "const": "2.5.0"
+            }
+          }
+        },
+        {
+          "$ref": "http://asyncapi.com/schema-store/2.5.0.json"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
**Description**

This PR adds missing AsyncAPI v2.5.0 schema to the `all.schema-store.json` doc.

cc @derberg